### PR TITLE
Workflow to Deploy Shraga Docs to S3

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,14 +11,14 @@ permissions:
 
 env:
   AWS_REGION: sa-east-1
-  
-permissions:
-  id-token: write
-  contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,9 +9,6 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  AWS_REGION: sa-east-1
-
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy to S3
 on:
   push:
     branches:
-      - "**"
+      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,10 +16,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
-    permissions:
-      id-token: write
-      contents: read
-
     steps:
       - uses: actions/checkout@v3
       - name: configure aws credentials

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,44 @@
+name: Deploy to S3
+
+on:
+  push:
+    branches:
+      - "**"
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: sa-east-1
+  
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::506746133768:role/ShragaDocsGitHubActions
+          aws-region: eu-west-2
+          audience: https://token.actions.githubusercontent.com
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      - name: Install dependencies and build
+        run: |
+          npm install
+          npm run build
+
+      - name: Sync with S3
+        run: |
+          aws s3 sync --delete ./build s3://shraga-docs


### PR DESCRIPTION
Website is available at http://shraga-docs.s3-website.eu-west-2.amazonaws.com.

The terraform repo seems to be pretty out of sync so I created the AWS resources manually (S3 bucket and IAM role)

To enable HTTPS, we need to add a CloudFront distribution in front of the S3 bucket. @synhershko let me know what domain we'll use so I can issue a TLS certificate.